### PR TITLE
INJIMOB-3692 : New api call for adaptive biometric feature

### DIFF
--- a/Sources/securekeystore/Biometrics/BiometricsImpl.swift
+++ b/Sources/securekeystore/Biometrics/BiometricsImpl.swift
@@ -90,29 +90,31 @@ class BiometricsImpl: BiometricsProtocol {
         return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
     }
     
-    /// Detects the type of biometric authentication supported by the device.
-    /// Returns: "FACE" for Face ID, "FINGERPRINT" for Touch ID, or "NONE"
+    enum SupportedBiometricType: String {
+        case face = "FACE"
+        case fingerprint = "FINGERPRINT"
+        case none = "NONE"
+    }
+    
     func getSupportedBiometricType() -> String {
         let context = LAContext()
         var error: NSError?
         
-        // Must call canEvaluatePolicy first to populate biometryType.
         let canEvaluate = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
         
         if #available(iOS 11.0, *) {
             switch context.biometryType {
             case .faceID:
-                return "FACE"
+                return SupportedBiometricType.face.rawValue
             case .touchID:
-                return "FINGERPRINT"
+                return SupportedBiometricType.fingerprint.rawValue
             case .none:
-                return "NONE"
+                return SupportedBiometricType.none.rawValue
             @unknown default:
-                return "NONE"
+                return SupportedBiometricType.none.rawValue
             }
         } else {
-            // Pre-iOS 11: biometryType is unavailable, fall back to canEvaluate
-            return canEvaluate ? "FINGERPRINT" : "NONE"
+            return canEvaluate ? SupportedBiometricType.fingerprint.rawValue : SupportedBiometricType.none.rawValue
         }
     }
     

--- a/Sources/securekeystore/Biometrics/BiometricsImpl.swift
+++ b/Sources/securekeystore/Biometrics/BiometricsImpl.swift
@@ -90,6 +90,36 @@ class BiometricsImpl: BiometricsProtocol {
         return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
     }
     
+    /// Detects the type of biometric authentication supported by the device.
+    /// Returns: "FACE" for Face ID, "FINGERPRINT" for Touch ID, or "NONE"
+    func getSupportedBiometricType() -> String {
+        let context = LAContext()
+        var error: NSError?
+        
+        // Must call canEvaluatePolicy first to populate biometryType
+        let canEvaluate = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+        
+        if !canEvaluate {
+            return "NONE"
+        }
+        
+        if #available(iOS 11.0, *) {
+            switch context.biometryType {
+            case .faceID:
+                return "FACE"
+            case .touchID:
+                return "FINGERPRINT"
+            case .none:
+                return "NONE"
+            @unknown default:
+                return "NONE"
+            }
+        } else {
+            // Pre-iOS 11: only Touch ID existed
+            return canEvaluate ? "FINGERPRINT" : "NONE"
+        }
+    }
+    
     // Private method to check if authentication is required based on the key type and its timeout
     private func isAuthenticationRequired(forKeyType keyType: String) -> Bool {
         return authQueue.sync {

--- a/Sources/securekeystore/Biometrics/BiometricsImpl.swift
+++ b/Sources/securekeystore/Biometrics/BiometricsImpl.swift
@@ -90,13 +90,13 @@ class BiometricsImpl: BiometricsProtocol {
         return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
     }
     
-    enum SupportedBiometricType: String {
+    enum AvailableBiometricType: String {
         case face = "FACE"
         case fingerprint = "FINGERPRINT"
         case none = "NONE"
     }
     
-    func getSupportedBiometricType() -> String {
+    func getAvailableBiometricType() -> String {
         let context = LAContext()
         var error: NSError?
         
@@ -105,16 +105,16 @@ class BiometricsImpl: BiometricsProtocol {
         if #available(iOS 11.0, *) {
             switch context.biometryType {
             case .faceID:
-                return SupportedBiometricType.face.rawValue
+                return AvailableBiometricType.face.rawValue
             case .touchID:
-                return SupportedBiometricType.fingerprint.rawValue
+                return AvailableBiometricType.fingerprint.rawValue
             case .none:
-                return SupportedBiometricType.none.rawValue
+                return AvailableBiometricType.none.rawValue
             @unknown default:
-                return SupportedBiometricType.none.rawValue
+                return AvailableBiometricType.none.rawValue
             }
         } else {
-            return canEvaluate ? SupportedBiometricType.fingerprint.rawValue : SupportedBiometricType.none.rawValue
+            return canEvaluate ? AvailableBiometricType.fingerprint.rawValue : AvailableBiometricType.none.rawValue
         }
     }
     

--- a/Sources/securekeystore/Biometrics/BiometricsImpl.swift
+++ b/Sources/securekeystore/Biometrics/BiometricsImpl.swift
@@ -96,12 +96,8 @@ class BiometricsImpl: BiometricsProtocol {
         let context = LAContext()
         var error: NSError?
         
-        // Must call canEvaluatePolicy first to populate biometryType
+        // Must call canEvaluatePolicy first to populate biometryType.
         let canEvaluate = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
-        
-        if !canEvaluate {
-            return "NONE"
-        }
         
         if #available(iOS 11.0, *) {
             switch context.biometryType {
@@ -115,7 +111,7 @@ class BiometricsImpl: BiometricsProtocol {
                 return "NONE"
             }
         } else {
-            // Pre-iOS 11: only Touch ID existed
+            // Pre-iOS 11: biometryType is unavailable, fall back to canEvaluate
             return canEvaluate ? "FINGERPRINT" : "NONE"
         }
     }

--- a/Sources/securekeystore/Biometrics/BiometricsProtocol.swift
+++ b/Sources/securekeystore/Biometrics/BiometricsProtocol.swift
@@ -3,5 +3,5 @@ import LocalAuthentication
 public protocol BiometricsProtocol {
     func authenticateUser(keyType: String, reason: String, completion: @escaping (Bool, Error?) -> Void)
     func hasBiometricsEnabled()->Bool
-    func getSupportedBiometricType()->String
+    func getAvailableBiometricType()->String
 }

--- a/Sources/securekeystore/Biometrics/BiometricsProtocol.swift
+++ b/Sources/securekeystore/Biometrics/BiometricsProtocol.swift
@@ -3,4 +3,5 @@ import LocalAuthentication
 public protocol BiometricsProtocol {
     func authenticateUser(keyType: String, reason: String, completion: @escaping (Bool, Error?) -> Void)
     func hasBiometricsEnabled()->Bool
+    func getSupportedBiometricType()->String
 }

--- a/Sources/securekeystore/SecureKeystoreImpl.swift
+++ b/Sources/securekeystore/SecureKeystoreImpl.swift
@@ -148,8 +148,8 @@ public class SecureKeystoreImpl:SecureKeystoreProtocol {
         return biometrics.hasBiometricsEnabled()
     }
     
-    public func getSupportedBiometricType()->String{
-        return biometrics.getSupportedBiometricType()
+    public func getAvailableBiometricType()->String{
+        return biometrics.getAvailableBiometricType()
     }
     
     public func updatePopup(title:String, desc:String){

--- a/Sources/securekeystore/SecureKeystoreImpl.swift
+++ b/Sources/securekeystore/SecureKeystoreImpl.swift
@@ -148,6 +148,10 @@ public class SecureKeystoreImpl:SecureKeystoreProtocol {
         return biometrics.hasBiometricsEnabled()
     }
     
+    public func getSupportedBiometricType()->String{
+        return biometrics.getSupportedBiometricType()
+    }
+    
     public func updatePopup(title:String, desc:String){
         BiometricsImpl.updatePopup(title: title, desc:desc)
     }

--- a/Sources/securekeystore/SecureKeystoreProtocol.swift
+++ b/Sources/securekeystore/SecureKeystoreProtocol.swift
@@ -17,7 +17,7 @@ public protocol SecureKeystoreProtocol {
     
     func hasBiometricsEnabled() -> Bool
     
-    func getSupportedBiometricType() -> String
+    func getAvailableBiometricType() -> String
     
     func updatePopup(title: String, desc: String)
     

--- a/Sources/securekeystore/SecureKeystoreProtocol.swift
+++ b/Sources/securekeystore/SecureKeystoreProtocol.swift
@@ -17,6 +17,8 @@ public protocol SecureKeystoreProtocol {
     
     func hasBiometricsEnabled() -> Bool
     
+    func getSupportedBiometricType() -> String
+    
     func updatePopup(title: String, desc: String)
     
     func generateKey(alias: String, authRequired: Bool, authTimeout: Int32, onSuccess: @escaping (Bool) -> Void, onFailure: @escaping(_ code: String, _ message: String) -> Void)


### PR DESCRIPTION
## Added a new api call for ios side to detect the biometric type in ios either face id or touch id
### Changes made
- added a new api call getAvailableBiometricType that supports LAContext.biometryType which is the official iOS API for detecting Face ID vs Touch ID 
- Each device has only one biometric type (Face ID or Touch ID) the api call detect the authentication method and returns the specific authentication to wallet via library 

## issue ticket number and link
> [INJIMOB-3692](https://mosip.atlassian.net/browse/INJIMOB-3692)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes a new public API to detect the device's available biometric type.
  * Returns one of: FACE, FINGERPRINT, or NONE.
  * Lets apps adapt UI labels, prompts and fallback authentication flows based on the detected biometric hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->